### PR TITLE
Add grunt task to start local server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,15 @@ module.exports = function(grunt) {
         }
       },
 
+      connect: {
+        server: {
+          options: {
+            base: 'build',
+            open: true
+          }
+        }
+      },
+
       // karma: {
       //   app: {
       //     options: {
@@ -125,6 +134,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('js-build', ['concat:js', 'jshint']);
     grunt.registerTask('css-build', ['sass']);
+    grunt.registerTask('serve', ['default', 'connect', 'watch']);
     grunt.registerTask('default', ['clean', 'copy', 'concat', 'jshint', 'sass']);
 
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-sass": "^1.0.0",


### PR DESCRIPTION
Hello @mattgrosso!

Thanks a lot for creating and hosting [GameTable](https://gametableapp.herokuapp.com/)! I came across it via [this thread on r/boardgames](https://www.reddit.com/r/boardgames/comments/5rp85c/any_good_alternatives_to_gameshelf/) when I was looking for a good alternative to [boardgamecaddie](http://www.boardgamecaddie.com/) -- which is down as I'm posting this.

I'm especially happy that you've open sourced your work! Are you interested in receiving Pull Requests? This one is small, but convenient -- it adds a grunt task that starts a local static server and launches the GameTable app.

I started with this PR because the local links don't otherwise load correctly when I open the `build/index.html` file locally:

![image](https://user-images.githubusercontent.com/5176154/34422027-7f927aca-ebd8-11e7-84c5-e2c1168b8f7d.png)

But, with this code change, running `grunt serve` results in a browser window opening that looks like so:

![image](https://user-images.githubusercontent.com/5176154/34422077-d4353e8c-ebd8-11e7-9dfc-27518ebe7425.png)

If you'd like changes to this PR please let me know. If you'd prefer not to merge it, that's fine too. And if you're open to it, then I may send some more PRs your way as I use GameTable a bit more.

Thanks again!